### PR TITLE
fix: disables the no-proptype-builtins rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,5 +16,6 @@ module.exports = {
         "@typescript-eslint/no-use-before-define": 0,
         "@typescript-eslint/no-explicit-any": 0,
         "@typescript-eslint/array-type": [1, { default: "array-simple" }],
+        "no-prototype-builtins": 0,
     },
 }


### PR DESCRIPTION
Was discussed in a PR that we don't need this rule and that the fix made
the code harder to read.